### PR TITLE
Us14 offline stöd

### DIFF
--- a/app/src/main/java/com/ma25/fixmaster/repository/ObjectRepository.kt
+++ b/app/src/main/java/com/ma25/fixmaster/repository/ObjectRepository.kt
@@ -1,7 +1,6 @@
 package com.ma25.fixmaster.repository
 
 import com.google.firebase.Timestamp
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ma25.fixmaster.model.IssueReport
@@ -12,8 +11,8 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 
 class ObjectRepository : ReportRepository {
+
     private val db = FirebaseFirestore.getInstance()
-    private val auth = FirebaseAuth.getInstance()
 
     // ========================
     // OBJECTS: get by QR
@@ -25,28 +24,25 @@ class ObjectRepository : ReportRepository {
                 .get()
                 .await()
 
-            if (!snapshot.isEmpty) snapshot.documents[0].toObject(ReportObject::class.java) else null
+            if (!snapshot.isEmpty) {
+                snapshot.documents[0].toObject(ReportObject::class.java)
+            } else null
         } catch (e: Exception) {
             null
         }
     }
 
     // ========================
-    // CREATE REPORT (User)
-    // ✅ adds createdBy automatically
+    // CREATE REPORT (User) - OFFLINE FRIENDLY ✅
     // ========================
     override suspend fun addReport(report: IssueReport) {
-        val uid = auth.currentUser?.uid ?: return
-
-        val reportWithOwner = report.copy(
-            createdBy = uid,
-            // timestamp optional: if you want serverTimestamp in firestore set it in map instead
+        val reportToSave = report.copy(
+            // تأكد يوجد timestamp محلي حتى Offline
             timestamp = report.timestamp ?: Timestamp.now()
         )
 
-        db.collection("reports")
-            .add(reportWithOwner)
-            .await()
+        // IMPORTANT: لا await هنا، لكي لا يعلق Offline
+        db.collection("reports").add(reportToSave)
     }
 
     // ========================
@@ -62,8 +58,7 @@ class ObjectRepository : ReportRepository {
                 }
 
                 val reports = snapshot?.documents?.mapNotNull { doc ->
-                    doc.toObject(IssueReport::class.java)
-                        ?.copy(id = doc.id)
+                    doc.toObject(IssueReport::class.java)?.copy(id = doc.id)
                 } ?: emptyList()
 
                 trySend(reports)
@@ -94,8 +89,9 @@ class ObjectRepository : ReportRepository {
         awaitClose { listener.remove() }
     }
 
-    // Rapport av ID
-
+    // ========================
+    // Report by ID
+    // ========================
     suspend fun getReportById(reportId: String): IssueReport? {
         return try {
             val doc = db.collection("reports")
@@ -109,11 +105,10 @@ class ObjectRepository : ReportRepository {
         }
     }
 
-
     // ========================
     // ADMIN - update status
     // ========================
-    override suspend fun updateReportStatus(reportId: String, newStatus: String,) {
+    override suspend fun updateReportStatus(reportId: String, newStatus: String) {
         val updateData = mutableMapOf<String, Any>(
             "status" to newStatus
         )

--- a/app/src/main/java/com/ma25/fixmaster/ui/ReportActivity.kt
+++ b/app/src/main/java/com/ma25/fixmaster/ui/ReportActivity.kt
@@ -1,15 +1,11 @@
 package com.ma25.fixmaster.ui
 
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.Uri
 import android.os.Bundle
-import android.widget.Button
-import android.widget.ImageView
-import android.widget.ProgressBar
-import android.widget.RadioButton
-import android.widget.RadioGroup
-import android.widget.TextView
-import android.widget.Toast
+import android.widget.*
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -88,7 +84,6 @@ class ReportActivity : AppCompatActivity() {
         tvTitle = findViewById(R.id.tvObjectTitle)
         rgFaultType = findViewById(R.id.rgFaultType)
         rgPriority = findViewById(R.id.rgPriority)
-
         etComment = findViewById(R.id.etComment)
 
         btnSubmit = findViewById(R.id.btnSubmit)
@@ -131,15 +126,28 @@ class ReportActivity : AppCompatActivity() {
             val comment = etComment.text?.toString()
                 .orEmpty()
                 .trim()
-                .takeIf { it.isNotBlank() } // null om tom
+                .takeIf { it.isNotBlank() }
+
+            // ✅ (اختياري) رسالة للمستخدم إذا Offline
+            val online = isOnline()
+            if (!online) {
+                Toast.makeText(
+                    this,
+                    "Du är offline. Ärendet sparas och synkas när du är online.",
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+
+            // ✅ أهم شيء: إذا Offline لا تمرّر صورة (لأن Storage لا يعمل Offline)
+            val imageToSend = if (online) latestImageUri else null
 
             viewModel.submitReport(
                 objectId = objectId,
                 objectName = objectName,
                 faultType = faultType,
-                priority = priority,
                 createdBy = uid,
-                imageUri = latestImageUri,
+                priority = priority,
+                imageUri = imageToSend,
                 comment = comment
             )
         }
@@ -154,17 +162,11 @@ class ReportActivity : AppCompatActivity() {
 
                     when (state) {
                         is ReportState.Success -> {
-                            startActivity(
-                                Intent(this@ReportActivity, ReportSuccessActivity::class.java)
-                            )
+                            startActivity(Intent(this@ReportActivity, ReportSuccessActivity::class.java))
                             finish()
                         }
                         is ReportState.Error -> {
-                            Toast.makeText(
-                                this@ReportActivity,
-                                state.message,
-                                Toast.LENGTH_SHORT
-                            ).show()
+                            Toast.makeText(this@ReportActivity, state.message, Toast.LENGTH_SHORT).show()
                         }
                         else -> Unit
                     }
@@ -197,6 +199,14 @@ class ReportActivity : AppCompatActivity() {
 
         latestImageUri = uri
         takePictureLauncher.launch(uri)
+    }
+
+    // ✅ فقط لتحديد هل نمرّر صورة أم لا + رسالة
+    private fun isOnline(): Boolean {
+        val cm = getSystemService(ConnectivityManager::class.java)
+        val network = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(network) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
     }
 
     companion object {

--- a/app/src/main/java/com/ma25/fixmaster/ui/ReportViewModel.kt
+++ b/app/src/main/java/com/ma25/fixmaster/ui/ReportViewModel.kt
@@ -1,7 +1,10 @@
 package com.ma25.fixmaster.ui
 
+import android.app.Application
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.Uri
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.storage.FirebaseStorage
 import com.ma25.fixmaster.model.IssueReport
@@ -14,7 +17,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import java.util.UUID
 
-class ReportViewModel : ViewModel() {
+class ReportViewModel(app: Application) : AndroidViewModel(app) {
 
     private val repository = ObjectRepository()
     private val storage = FirebaseStorage.getInstance()
@@ -22,7 +25,6 @@ class ReportViewModel : ViewModel() {
     private val _state = MutableStateFlow<ReportState>(ReportState.Idle)
     val state: StateFlow<ReportState> = _state
 
-    // <--- ROBIN: Lade till "imageUri: Uri?" i slutet
     fun submitReport(
         objectId: String,
         objectName: String,
@@ -30,16 +32,53 @@ class ReportViewModel : ViewModel() {
         createdBy: String,
         priority: Priority,
         imageUri: Uri?,
-        comment: String?)
-    {
-        _state.value = ReportState.Loading
-
+        comment: String?
+    ) {
         viewModelScope.launch {
             try {
-                delay(1000)
+                val online = isOnline()
+
+                // ✅ إذا Offline: أعطِ رسالة واضحة للمستخدم ولا تعمل Loading طويل
+                if (!online) {
+                    // ممنوع رفع صورة Offline
+                    if (imageUri != null) {
+                        _state.value = ReportState.Error(
+                            "Du är offline. Bild kan inte laddas upp utan internet. Skicka utan bild."
+                        )
+                        return@launch
+                    }
+
+                    // رسالة Offline (ليست خطأ فعليًا، لكنها تُستخدم لعرض Toast بسهولة)
+                    _state.value = ReportState.Error(
+                        "Du är offline. Ärendet sparas lokalt och synkas när du är online."
+                    )
+
+                    // أنشئ report بدون صورة (Firestore queue)
+                    val newReport = IssueReport(
+                        objectId = objectId,
+                        objectName = objectName,
+                        qrCode = objectId,
+                        description = faultType,
+                        status = "Ny",
+                        imageUrl = null,
+                        createdBy = createdBy,
+                        priority = priority.name,
+                        comment = comment
+                    )
+
+                    // مهم: addReport يجب أن لا يستخدم await في Firestore أثناء Offline
+                    repository.addReport(newReport)
+
+                    // بعد عرض الرسالة، روح للنجاح
+                    _state.value = ReportState.Success
+                    return@launch
+                }
+
+                // ✅ Online: هنا نستخدم Loading ونرفع الصورة لو موجودة
+                _state.value = ReportState.Loading
+                delay(200) // اختياري
 
                 var downloadUrl: String? = null
-
                 if (imageUri != null) {
                     val fileName = "reports/${UUID.randomUUID()}.jpg"
                     val ref = storage.reference.child(fileName)
@@ -53,7 +92,7 @@ class ReportViewModel : ViewModel() {
                     qrCode = objectId,
                     description = faultType,
                     status = "Ny",
-                    imageUrl = downloadUrl, // <--- ROBIN: Skickar med länken hit (US4)
+                    imageUrl = downloadUrl,
                     createdBy = createdBy,
                     priority = priority.name,
                     comment = comment
@@ -66,5 +105,14 @@ class ReportViewModel : ViewModel() {
                 _state.value = ReportState.Error("Fel: ${e.message}")
             }
         }
+    }
+
+    private fun isOnline(): Boolean {
+        val cm = getApplication<Application>()
+            .getSystemService(ConnectivityManager::class.java)
+
+        val network = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(network) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
     }
 }


### PR DESCRIPTION
Adds basic offline support when creating reports.

Changes:
- Reports can now be created while the device is offline.
- The report is stored locally and automatically synced to Firebase when the device goes online again.
- Added user feedback message when the device is offline.


Files updated:
- ObjectRepository.kt
- ReportViewModel.kt
- ReportActivity.kt

Tested:
- Create report while online → saved to Firebase immediately.
- Create report while offline → stored locally and synced when connection returns.